### PR TITLE
plan testow SUAS + pelne FOV z OAK-D PRO W

### DIFF
--- a/docs/gimbal setup.md
+++ b/docs/gimbal setup.md
@@ -1,0 +1,45 @@
+# Gimbal — skrócona instrukcja
+
+## Podłączenie
+1. Sygnał serwa → **MAIN 7** na Cube.
+2. Zasilanie serwa → **BEC 5 V** wpięty w rail MAIN (+/−). Cube sam nie zasila railu — bez BEC-a serwo dostanie sygnał, ale nie ruszy.
+3. Masa BEC-a wspólna z Cube (załatwia to wpięcie w rail).
+
+## Parametry (Mission Planner)
+
+| Parametr | Wartość | Po co |
+|---|---|---|
+| `MNT1_TYPE` | 1 | Włącza obsługę gimbala (typ: serwo) |
+| `SERVO7_FUNCTION` | 7 | Pin MAIN 7 = pitch gimbala |
+| `SERVO7_MIN/MAX` | ~1100/1900 | Zakres PWM = fizyczne krańce gimbala |
+| `SERVO7_TRIM` | ~1500 | Pozycja neutralna |
+| `SERVO7_REVERSED` | 0/1 | Jedzie w złą stronę → zmień |
+| `MNT1_PITCH_MIN/MAX` | −90 / 45 | Jakie kąty odpowiadają krańcom |
+| `MNT1_DEFLT_MODE` | 2 | Słuchaj komend MAVLink (tego używa nasz kod) |
+
+**Po zapisaniu → reboot Cube'a.** Bez restartu gimbal nie działa — to najczęstszy błąd.
+
+## Kalibracja (bez śmigieł)
+1. Wyślij pitch `0` (MP/MAVProxy: `mount pitch 0`) → kamera poziomo. Nie jest → koryguj `TRIM` lub przełóż orczyk.
+2. Wyślij `-90` → prosto w dół. Jedzie w górę → `SERVO7_REVERSED=1`.
+3. Na krańcach serwo buczy/dociska → zawęź `MIN/MAX` o 20–50 µs.
+4. `MNT1_PITCH_MIN/MAX` ustaw na rzeczywiste kąty osiągane na krańcach.
+
+## Test przez ROS
+```bash
+ros2 run drone_hardware drone_handler --ros-args -p fc_ip:=/dev/ttyACM0
+```
+Drugi terminal:
+```bash
+ros2 topic pub --once knr_hardware/gimbal_pitch std_msgs/msg/Float32 "{data: -45.0}"
+```
+Serwo ma stanąć na −45°. Sprawdź też `0` i `-90`. Działa → tracker działa bez zmian w kodzie.
+
+## Gdy coś nie gra
+- **Nic nie rusza** → brak reboota albo brak zasilania railu (BEC).
+- **PWM na ch7 zmienia się (Status → servo outputs), serwo stoi** → zasilanie/kabel serwa.
+- **PWM stoi w miejscu** → parametry (`SERVO7_FUNCTION`, `MNT1_TYPE`, tryb MAVLink).
+- **Kąty się nie zgadzają** → `MNT1_PITCH_MIN/MAX`.
+- **Reaguje na RC, nie na kod** → `MNT1_DEFLT_MODE=2`.
+
+Kalibruj **po finalnym montażu mechanicznym** — przełożenie orczyka później unieważnia wszystko.

--- a/docs/plan_testow_suas.md
+++ b/docs/plan_testow_suas.md
@@ -1,0 +1,173 @@
+# Plan testow SUAS — real (Jetson + Orange Cube + OAK-D)
+
+Kazdy terminal zaczyna od:
+```bash
+cd ~/Dron_symulacja && source install/setup.bash
+```
+
+Build (raz, po zmianach w kodzie):
+```bash
+colcon build --symlink-install --packages-select drone_hardware drone_detector drone_autonomy drone_bringup drone_camera
+```
+
+---
+
+## 0. Przed startem
+
+```bash
+sudo nvpmodel -m 1 && sudo jetson_clocks && sudo nvpmodel -q   # 25W
+ls /dev/ttyACM*                                                # port Cube'a
+ls -lh src/drone_detector/models/MODEL4.engine                 # model TensorRT istnieje?
+```
+
+Bez smigiel. Cube po reboocie (po zapisie parametrow gimbala — patrz `docs/gimbal setup.md`).
+
+---
+
+## 1. drone_handler  [T1]
+
+```bash
+ros2 run drone_hardware drone_handler --ros-args -p fc_ip:=/dev/ttyACM0
+```
+
+Sprawdzenie (T2):
+```bash
+ros2 topic echo knr_hardware/telemetry --once
+ros2 topic pub --once knr_hardware/gimbal_pitch std_msgs/msg/Float32 "{data: 0.0}"    # poziomo
+ros2 topic pub --once knr_hardware/gimbal_pitch std_msgs/msg/Float32 "{data: -45.0}"  # w dol
+ros2 topic pub --once knr_hardware/gimbal_pitch std_msgs/msg/Float32 "{data: 30.0}"   # pozycja SEARCH
+```
+**PASS:** serwo staje na zadanym kacie. Nie rusza → BEC / reboot Cube'a / `MNT1_DEFLT_MODE=2`.
+
+---
+
+## 2. suas_detect_jetson  [T2]
+
+```bash
+ros2 launch drone_bringup suas_detect_jetson.launch.py
+# opcje: conf:=0.35  camera_topic:=/oak/rgb/image_raw  model_path:=/pelna/sciezka/MODEL4.engine
+```
+
+Sprawdzenie (T3):
+```bash
+ros2 topic hz /oak/rgb/image_raw
+ros2 topic echo /oak/rgb/image_raw --field height --once   # ma byc 760 (config 12MP + ISP 1/4)
+ros2 topic hz /tent_detections
+ros2 topic echo /tent_detections --once
+```
+**PASS:** w logu `FPS ... Detekcje namiotu: X/Y`, `detected: true` na namiocie.
+
+Podglad na stacji naziemnej (ta sama siec ROS_DOMAIN_ID):
+```bash
+ros2 run rqt_image_view rqt_image_view /tent_detections/image/compressed
+```
+
+---
+
+## 3. suas_gimbal_controller  [T3]
+
+Wymaga: T1 + T2 dzialaja.
+
+```bash
+ros2 launch drone_bringup suas_gimbal_controller.launch.py img_h:=760 vfov_deg:=<zmierzone>
+# opcje: damping:=0.4  deadzone:=0.06  control_rate:=10.0
+```
+
+Domyslne `img_h:=1024 vfov_deg:=114.6` sa dla Gazebo — nie uzywaj na realu.
+
+### 3a. Pomiar VFOV — raz, przy dzialajacym T2
+
+Wklej w terminal, przepisz `VFOV` do `vfov_deg:=`:
+
+```bash
+python3 - <<'EOF'
+import math, rclpy
+from sensor_msgs.msg import CameraInfo
+rclpy.init(); n = rclpy.create_node('fov'); box = []
+n.create_subscription(CameraInfo, '/oak/rgb/camera_info', box.append, 10)
+while not box: rclpy.spin_once(n)
+m = box[0]
+print(f"img_h  = {m.height}")
+print(f"VFOV   = {math.degrees(2*math.atan(m.height/(2*m.k[4]))):.1f}")
+EOF
+```
+
+Powtorz po kazdej zmianie `i_resolution` / `i_isp_den` w `config/oak_rgb.yaml`.
+
+Logi: `[SLEDZE]` dosuwa, `[CENTR]` wycentrowany, `[SZUKAM]` brak namiotu.
+
+**Test:** namiot ponizej srodka kadru → gimbal jedzie w dol → namiot wraca na srodek.
+Oscyluje → `damping:=0.25`. Reaguje za wolno → `damping:=0.6`.
+Jedzie w zla strone → zly znak/`SERVO7_REVERSED`, nie zmieniaj kodu.
+
+---
+
+## 4. Nagrywanie podgladu z detekcja  [T4]
+
+Najpierw zmierz realna czestotliwosc nagrywanego topicu — to jest `fps` do zapisu:
+```bash
+ros2 topic hz /tent_detections/image
+```
+Uwaga: to rate YOLO, nie kamery. Kamera daje 15, detektor zwykle mniej.
+
+**Bag (zalecane — fps nieistotny, bag trzyma znaczniki czasu):**
+```bash
+mkdir -p ~/loty && ros2 bag record -o ~/loty/test_$(date +%m%d_%H%M) \
+  /tent_detections/image/compressed /tent_detections /knr_hardware/telemetry
+```
+Stop: `Ctrl+C`. Odtworzenie pozniej:
+```bash
+ros2 bag play ~/loty/test_XXXX
+ros2 run rqt_image_view rqt_image_view /tent_detections/image/compressed
+```
+
+**Albo od razu plik .avi — podaj `fps` z pomiaru wyzej:**
+```bash
+ros2 run drone_camera video_recorder --ros-args \
+  -p camera_topic:=/tent_detections/image -p fps:=15.0 \
+  -p save_directory_base:=/home/jetsonknr/saved_video
+```
+Start / stop nagrywania (T5):
+```bash
+ros2 service call knr_video/turn_on_video  drone_interfaces/srv/TurnOnVideo  "{}"
+ros2 service call knr_video/turn_off_video drone_interfaces/srv/TurnOffVideo "{}"
+```
+Plik: `<save_directory_base>/<N>/videoN.avi` (MJPG). Zly `fps` = wideo za szybkie/wolne.
+
+Miejsce na dysku przed lotem:
+```bash
+df -h ~
+```
+
+---
+
+## Kolejnosc uruchamiania (podsumowanie)
+
+| Term | Co | Kiedy |
+|---|---|---|
+| T1 | `drone_handler` | pierwszy, czekaj na polaczenie z FC |
+| T2 | `suas_detect_jetson` | gdy kamera widoczna, czekaj na `ready` + FPS |
+| T3 | `suas_gimbal_controller` | dopiero gdy `/tent_detections` publikuje |
+| T4 | `ros2 bag record` | tuz przed testem |
+
+Zamykanie: odwrotnie (T4 → T3 → T2 → T1), `Ctrl+C` w kazdym.
+
+---
+
+## Szybka diagnostyka
+
+```bash
+ros2 node list
+ros2 topic list | grep -E "tent|oak|knr_hardware"
+ros2 topic hz /tent_detections/image/compressed
+ros2 param get /suas_gimbal_controller vfov_deg
+tegrastats                                        # obciazenie GPU/CPU Jetsona
+```
+
+| Objaw | Sprawdz |
+|---|---|
+| Brak `/oak/rgb/image_raw` | kabel USB3, `i_pipeline_type: RGB` w `config/oak_rgb.yaml` |
+| Detektor sie nie laduje | sciezka `.engine`, engine zbudowany dla `imgsz=1024` |
+| `/tent_detections` pusty | `conf:=0.25`, namiot w kadrze, oswietlenie |
+| Gimbal stoi mimo `[SLEDZE]` | T1 zyje? `ros2 topic echo knr_hardware/gimbal_pitch` |
+| Laguje obraz na GCS | nagrywaj lokalnie, na GCS tylko `image/compressed` |

--- a/docs/suas_tracking.md
+++ b/docs/suas_tracking.md
@@ -1,3 +1,7 @@
+sudo nvpmodel -m 1
+sudo jetson_clocks        # powtórz PO zmianie trybu
+sudo nvpmodel -q          # potwierdź: 25W
+
 # Misja namiotowa — co jest czym i jak uruchomić
 
 Wariant ArduPilot + Gazebo (branch `ardupilot_gz`).

--- a/src/drone_bringup/config/oak_rgb.yaml
+++ b/src/drone_bringup/config/oak_rgb.yaml
@@ -1,11 +1,17 @@
 /oak:
   ros__parameters:
     camera:
-      i_pipeline_type: 'RGB'   # tylko kamera RGB (bez glebi i chmury punktow) - lekkie dla USB2
+      i_pipeline_type: 'RGB'   # tylko kamera RGB (bez glebi i chmury punktow)
       i_nn_type: 'none'        # bez sieci na kamerze, YOLO liczy na Jetsonie
     rgb:
-      i_resolution: '1080P'
-      i_fps: 30.0
-      i_output_isp: true
-      i_isp_num: 1        # bylo domyslnie 2
-      i_isp_den: 1        # bylo domyslnie 3  -> 2/3 z 1080p = 720p
+      # OAK-D PRO W: obiektyw wide siedzi na CAM_A i jest uzywany zawsze - nie ma
+      # parametru "wide" do wlaczenia. Ale sensor IMX378 jest 4:3 (4056x3040),
+      # a tryb '1080P' to 16:9 -> obcina gore i dol, czyli OS PITCHU gimbala.
+      # Dlatego pelna klatka 4:3 + zjazd ISP zamiast trybu 16:9.
+      i_resolution: '12MP'     # 4056x3040 - pelne pole widzenia obiektywu wide
+      i_isp_num: 1
+      i_isp_den: 4             # -> 1014x760 (4:3, pelny FOV, ~imgsz=1024)
+                               # 1/2 -> 2028x1520 jesli chcesz wiecej detalu (4x dane)
+                               # 1/3 NIE dziala: 3040/3 nie jest calkowite
+      i_output_isp: true       # publikuj wyjscie ISP (respektuje skalowanie powyzej)
+      i_fps: 15.0

--- a/src/drone_camera/drone_camera/video_recorder.py
+++ b/src/drone_camera/drone_camera/video_recorder.py
@@ -17,8 +17,11 @@ class VideoRecorder(Node):
         # prepering dir to save video
         self.declare_parameter('camera_topic', 'camera')
         self.declare_parameter('save_directory_base', 'saved_video')
+        # fps zapisu do pliku - ustaw na REALNA czestotliwosc nagrywanego topicu
+        # (sprawdz: ros2 topic hz <topic>), inaczej wideo odtwarza sie za szybko/wolno
+        self.declare_parameter('fps', 15.0)
 
-
+        self.fps = float(self.get_parameter('fps').value)
         camera_topic = self.get_parameter('camera_topic').get_parameter_value().string_value
         self.get_logger().info(f'camera_topic: {camera_topic}')
         self.subscription = self.create_subscription(
@@ -63,10 +66,10 @@ class VideoRecorder(Node):
         self.video_name += 1
         height ,width , c = self.current_frame.shape
         size = (int(width), int(height))
-        self.result = cv2.VideoWriter(self.save_directory+"/video"+str(self.video_name)+".avi", cv2.VideoWriter_fourcc(*'MJPG'), 10, size) 
+        self.result = cv2.VideoWriter(self.save_directory+"/video"+str(self.video_name)+".avi", cv2.VideoWriter_fourcc(*'MJPG'), self.fps, size)
         self._start_video_flag = True
         response.error = False
-        self.get_logger().info('Start making video')
+        self.get_logger().info(f'Start making video @ {self.fps} fps')
 
         return response
     


### PR DESCRIPTION
- docs/plan_testow_suas.md: kolejnosc uruchamiania (drone_handler ->
  suas_detect_jetson -> suas_gimbal_controller), nagrywanie podgladu
  z detekcja, pomiar VFOV z camera_info, diagnostyka
- oak_rgb.yaml: 1080P (16:9) obcinalo gore i dol kadru IMX378 (4:3), czyli os pitchu gimbala. Teraz 12MP + ISP 1/4 -> 1014x760, pelne pole widzenia obiektywu wide, rozmiar ~imgsz=1024 detektora
- video_recorder: fps jako parametr (bylo zaszyte 10) - przy innej czestotliwosci topicu wideo odtwarzalo sie w zlym tempie
- docs/gimbal setup.md: tresc instrukcji (plik byl pusty)